### PR TITLE
Update ci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,8 @@ jobs:
           working_directory: ~/magento2
           command: |
             REPODIR=$(realpath ~/project)
-            composer config allow-plugins --unset
-            composer config allow-plugins.magento/composer-dependency-version-audit-plugin false
-            composer config allow-plugins.magento/* true
+            composer config allow-plugins.magento/* false
+            composer config allow-plugins.magento/composer-installer true
             composer config "repositories.1" "{\"type\": \"path\", \"canonical\":true, \"url\": \"$REPODIR\", \"options\": {\"symlink\":false}}"
             composer config "repositories.2" "{\"type\": \"path\", \"canonical\":true, \"url\": \"$REPODIR/dev/composerstub/fastlane\"}"
             composer config minimum-stability dev


### PR DESCRIPTION
```
In PluginManager.php(281) : eval()'d code line 248:
                                                                               
  Higher matching version dev-develop 1091171 of bluefinchcommerce/module-che  
  ckout-fastlane was found in public repository packagist.org                  
                               than dev-develop in private /home/circleci/pro  
  ject. Public package might've been taken over by a malicious entity,         
                               please investigate and update package requirem  
  ent to match the version from the private repository                         
```

Ensure packagist.org repository version does not conflict with the version under test